### PR TITLE
Add a create timestamp to the summary documents

### DIFF
--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -800,6 +800,8 @@ def summarize(j, lariatcache):
                 summaryDict['Error'].append("schema data not found")
 
     summaryDict['summary_version'] = SUMMARY_VERSION
+    summaryDict['created'] = datetime.datetime.utcnow()
+
     uniq = str( j.acct['local_jobid'] if 'local_jobid' in j.acct else j.acct['id'])
     if 'cluster' in j.acct:
         uniq += "-" + j.acct['cluster']


### PR DESCRIPTION
The plan is to change the sync tracking mechanism to use timestamps rather than the current
write-back method. This should reduce bandwidth requirements for the mongo database as well as the need for the ingestor to use a writable user.