### PR TITLE
Alter info in rmsjitter error message.

### DIFF
--- a/pickler/job_stats.py
+++ b/pickler/job_stats.py
@@ -675,7 +675,7 @@ class Job(object):
         if m > 0:
             rmsjitter = math.sqrt(rmsjitter) / m
             if rmsjitter > 60:
-                self.errors.add("high rmsjitter {} for host {}".format(rmsjitter, host.name))
+                self.errors.add("HRJ {} {}".format(host.name, type_name))
 
         # OK, we fit the raw values into A.  Now fixup rollover and
         # convert units.


### PR DESCRIPTION
The old error message included the actual jitter value. This value meant
that the log message could not be deduplated and lead to huge summary
documents, some of which would not fit in the database.