### PR TITLE
Handle case where a metric is missing from one host

### DIFF
--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -152,6 +152,10 @@ def gentimedata(j, indices, ignorelist, isevent):
             if metric in ignorelist:
                 continue
 
+            if metric not in indices:
+                logging.warning('%s not in index list for %s', metric, host.name)
+                continue
+
             for interface in indices[metric].keys() + ["all"]:
                 if metric not in hostdata:
                     hostdata[metric] = {}


### PR DESCRIPTION
There are cases where a metric is absent from one host in a multi
host job. Before this would cause an unhandled exception that would
result in the job summarization failing.