### PR TITLE
Add ability to estimate physical core usage on Intel KNL

### DIFF
--- a/pickler/job_stats.py
+++ b/pickler/job_stats.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import datetime, numpy, os, sys, gzip
 import amd64_pmc, intel_process
+import phys_cores_process
 import re
 import procdump
 import string
@@ -764,6 +765,7 @@ class Job(object):
             del host.raw_stats
         amd64_pmc.process_job(self)
         intel_process.process_job(self)
+        phys_cores_process.process_job(self)
         # Clear mult, width from schemas. XXX
         for schema in self.schemas.itervalues():
             for e in schema.itervalues():

--- a/pickler/phys_cores_process.py
+++ b/pickler/phys_cores_process.py
@@ -1,0 +1,61 @@
+# Post processing to map virtual CPU cores to physical cores
+import numpy
+import os
+
+def intel_knl_map(virtcore):
+    """ return the physical core index given the (virtual) cpu number """
+    return virtcore % 68
+
+def intel_knl_rescale(a, idleidx):
+
+    totalticks = sum(a)
+    if totalticks == 0:
+        # has been seen in the data
+        return a
+
+    idle = a[idleidx] / sum(a)
+
+    if idle > 0.75:
+        a[idleidx] -= numpy.uint64(0.75 * sum(a))
+    else:
+        # total counts
+        newticks = 0.25 * sum(a)
+
+        # Set idle to zero and preserve the relative proportions of the other counters
+        a[idleidx] = numpy.uint64(0)
+        nonidleticks = sum(a)
+        a = numpy.uint64(a * newticks / nonidleticks)
+
+    return a
+
+def process_job(job):
+    if 'cpu' not in job.schemas:
+        return
+
+    for host in job.hosts.itervalues():
+        if 'cpu' not in host.stats:
+            continue
+
+        cpustats = host.stats['cpu']
+
+        if len(cpustats) == 272:
+            output = {}
+            for cpuidx, data in cpustats.iteritems():
+                realidx = str(intel_knl_map(int(cpuidx)))
+                if realidx not in output:
+                    output[realidx] = data
+                else:
+                    output[realidx] += data
+
+            cpuschema = job.get_schema('cpu')
+            cpuidle = cpuschema['idle'].index
+
+            for key in output.keys():
+                if len(output[key][:, ]) > 1:
+                    rates = numpy.diff(output[key], 1, 0)
+                    scaled_rates = numpy.apply_along_axis(intel_knl_rescale, 1, rates, cpuidle)
+                    output[key] = numpy.concatenate(( (output[key][0], ), scaled_rates), 0).cumsum(0)
+
+            host.stats['cputhreads'] = host.stats['cpu']
+            job.get_schema('cputhreads', cpuschema.desc)
+            host.stats['cpu'] = output

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -401,6 +401,7 @@ def getinterfacestats(hoststats, metricname, interface, indices):
 
 def getperinterfacemetrics():
     return [ "cpu", "mem", "sched", "intel_pmc3", "intel_uncore", "intel_hsw", "intel_hsw_cbo", "intel_hsw_hau", "intel_hsw_imc", "intel_hsw_qpi", "intel_hsw_pcu", "intel_hsw_r2pci", "intel_snb", "intel_snb_cbo", "intel_snb_imc", "intel_snb_pcu", "intel_snb_hau", "intel_snb_qpi", "intel_snb_r2pci",
+             "cputhreads",
              "amd64_core",
              "amd64_sock",
              "intel_skx",


### PR DESCRIPTION
The Intel KNL chips on Stampede 2 have 272 hardware threads on 68 cores which
are reported as 272 cores by the O/S. For most parallel HPC applications the
best way to use these chips is to run one task per core. So if you
view the CPU usage from the point of view of the hardware threads it
looks like the node is only being 25% used, whereas it is probably
optimal. This change generates an estimate of the physical core usage
based on the hardware thread statistics. The estimate is calulated as
follows:

The statistics for the 4 hardware threads on each core are summed. If
the core has 75% or more idle ticks then the top three quarters are ignored. This case
corresponds to three idle hardware threads out of four. If the core
is less than 75% idle then the idle ticks are zeroed and the
rest of the ticks are rescaled to 100% while maintaining their
relative ratios.

Of course this algorithm only generates an estimate of physical
core usage. There are pathalogical cases where it will not correctly
represent the usage. For example, if the code maxes out the four
hardware threads on a core for a quarter of the time then this
code would report 100% core usage whereas it will be closer to 25%
actual. This limitation is somewhat mitigated by doing the rescaling
independently at every time point.