### PR TITLE
Adding Support for TACC Frontera

### DIFF
--- a/assets/mongo_setup.js
+++ b/assets/mongo_setup.js
@@ -4242,5 +4242,4366 @@ summarydef.definitions.maxmemminus = {
     "unit": "ratio"
 };
 
-db.schema.update({_id: summarydef._id}, summarydef, {upsert: true})
+summaryDef0938 = {
+    "_id" : "summary-0.9.38",
+    "summary_version" : "0.9.38",
+    "definitions" : {
+        "maxmemminus" : {
+            "unit" : "ratio",
+            "type" : "instant",
+            "documentation" : "The maximum ratio of memory used to memory available for the nodes that were assigned to the job. The memory used value does not include the memory usage from the kernel page and slab caches. The memory statistics are obtained from the /sys/devices/system/node/node*/numastat file."
+        },
+        "maxmem" : {
+            "unit" : "ratio",
+            "type" : "instant",
+            "documentation" : "The maximum ratio of memory used to memory available for the nodes that were assigned to the job. Memory used value is obtained from the MemUsed statistic from the /sys/devices/system/node/node*/numastat file."
+        },
+        "numa" : {
+            "*" : {
+                "numa_hit" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/devices/system/node/node*/numastat",
+                    "source" : {
+                        "name" : "/sys/devices/system/node/node*/numastat",
+                        "type" : "sysfs"
+                    }
+                },
+                "numa_foreign" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/devices/system/node/node*/numastat",
+                    "source" : {
+                        "name" : "/sys/devices/system/node/node*/numastat",
+                        "type" : "sysfs"
+                    }
+                },
+                "other_node" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/devices/system/node/node*/numastat",
+                    "source" : {
+                        "name" : "/sys/devices/system/node/node*/numastat",
+                        "type" : "sysfs"
+                    }
+                },
+                "numa_miss" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/devices/system/node/node*/numastat",
+                    "source" : {
+                        "name" : "/sys/devices/system/node/node*/numastat",
+                        "type" : "sysfs"
+                    }
+                },
+                "interleave_hit" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/devices/system/node/node*/numastat",
+                    "source" : {
+                        "name" : "/sys/devices/system/node/node*/numastat",
+                        "type" : "sysfs"
+                    }
+                },
+                "local_node" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/devices/system/node/node*/numastat",
+                    "source" : {
+                        "name" : "/sys/devices/system/node/node*/numastat",
+                        "type" : "sysfs"
+                    }
+                }
+            }
+        },
+        "block" : {
+            "*" : {
+                "rd_ios" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                },
+                "rd_sectors" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                },
+                "io_ticks" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                },
+                "wr_ticks" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                },
+                "rd_merges" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                },
+                "wr_merges" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                },
+                "rd_ticks" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                },
+                "in_flight" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                },
+                "wr_sectors" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                },
+                "wr_ios" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                },
+                "time_in_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/block/*/stat",
+                    "source" : {
+                        "name" : "/sys/block/*/stat",
+                        "type" : "sysfs"
+                    }
+                }
+            }
+        },
+        "cpuall" : {
+            "unit" : "%",
+            "type" : "rate",
+            "documentation" : "The total recorded CPU core clock ticks per unit time expressed as a percentage. This value should by very close to 100 percent. Discrepencies in this value are typically due to data errors in the monitoring software rather than the problems with the HPC job."
+        },
+        "cpueff" : {
+            "nice" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "irq" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "user" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "idle" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "system" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "iowait" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "softirq" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            }
+        },
+        "cpu" : {
+            "nice" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "irq" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "user" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "idle" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "system" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "iowait" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            },
+            "softirq" : {
+                "unit" : "cs/s",
+                "type" : "rate",
+                "documentation" : "procfs metric read from /proc/stat",
+                "source" : {
+                    "name" : "/proc/stat",
+                    "type" : "procfs"
+                }
+            }
+        },
+        "vfs" : {
+            "*" : {
+                "file_use" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "procfs metric read from /proc/sys/fs/inode-state",
+                    "source" : {
+                        "name" : "/proc/sys/fs/inode-state",
+                        "type" : "procfs"
+                    }
+                },
+                "dentry_use" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "procfs metric read from /proc/sys/fs/dentry-state",
+                    "source" : {
+                        "name" : "/proc/sys/fs/dentry-state",
+                        "type" : "procfs"
+                    }
+                },
+                "inode_use" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "procfs metric read from /proc/sys/fs/inode-state",
+                    "source" : {
+                        "name" : "/proc/sys/fs/inode-state",
+                        "type" : "procfs"
+                    }
+                }
+            }
+        },
+        "mpirx" : {
+            "unit" : "B/s",
+            "type" : "rate",
+            "documentation" : "Estimate of the average rate of MPI data received per node over the InfiniBand interface. The estimate is calculated by subtracting the parallel filesystem data from the total InfiniBand data (for the compute resources that use the InfiniBand interconnect for parallel filesystem data)."
+        },
+        "membw" : {
+            "unit" : "B/s",
+            "type" : "rate",
+            "documentation" : "Average rate of data transferred to and from main memory per CPU socket."
+        },
+        "intel_ivb_hau" : {
+            "CTR0" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR1" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR2" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR3" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_ivb" : {
+            "LOAD_OPS_ALL" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_OPS_LLC_HIT" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_OPS_L1_HIT" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "SSE_DOUBLE_PACKED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_L1D_ALL" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CLOCKS_UNHALTED_CORE" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CLOCKS_UNHALTED_REF" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "SSE_DOUBLE_SCALAR" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "SIMD_DOUBLE_256" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "INSTRUCTIONS_RETIRED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_OPS_L2_HIT" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "nfs" : {
+            "*" : {
+                "FSSTAT_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READLINK_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "WRITE_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READ_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RENAME_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_updatepage" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "PATHCONF_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIR_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIR_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSSTAT_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RENAME_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SYMLINK_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "ACCESS_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIR_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "GETATTR_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RENAME_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSINFO_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKDIR_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "REMOVE_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SETATTR_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "short_write" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READ_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_open" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READLINK_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKDIR_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "GETATTR_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RENAME_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIR_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "delay" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "WRITE_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LOOKUP_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "COMMIT_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKNOD_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READ_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READ_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "REMOVE_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKNOD_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RMDIR_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "COMMIT_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "REMOVE_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "PATHCONF_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "extend_write" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_writepages" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "COMMIT_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "COMMIT_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "xprt_bklog_u" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_lookup" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RENAME_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RMDIR_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKDIR_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_lock" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READLINK_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_getdents" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LOOKUP_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RMDIR_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READLINK_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "dentry_revalidate" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIRPLUS_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LINK_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SYMLINK_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LINK_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SYMLINK_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "ACCESS_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIRPLUS_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RMDIR_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SETATTR_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIRPLUS_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "WRITE_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LINK_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIR_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "REMOVE_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LINK_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "ACCESS_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "PATHCONF_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SETATTR_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READ_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READLINK_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RMDIR_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READLINK_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "GETATTR_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READLINK_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LINK_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIR_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "normal_read" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READ_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIRPLUS_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "xprt_req_u" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SETATTR_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LINK_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RENAME_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSINFO_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "CREATE_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "write_page" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIRPLUS_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "PATHCONF_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "REMOVE_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "COMMIT_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "WRITE_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSINFO_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "silly_rename" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "WRITE_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "PATHCONF_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "PATHCONF_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSSTAT_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "PATHCONF_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SYMLINK_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "ACCESS_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "WRITE_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RMDIR_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READ_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKDIR_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIRPLUS_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "REMOVE_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKDIR_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "GETATTR_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "WRITE_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIRPLUS_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "xprt_bad_xids" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "CREATE_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKNOD_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKDIR_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "direct_write" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "xprt_sends" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "REMOVE_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "direct_read" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "GETATTR_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_writepage" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKNOD_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "CREATE_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "read_page" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSINFO_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKNOD_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RMDIR_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SYMLINK_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSINFO_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "setattr_trunc" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "congestion_wait" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "normal_write" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_fsync" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "CREATE_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LOOKUP_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_setattr" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "ACCESS_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RENAME_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSSTAT_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SYMLINK_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "GETATTR_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "inode_revalidate" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SYMLINK_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "CREATE_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "CREATE_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_readpages" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SETATTR_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSINFO_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "server_write" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "COMMIT_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSINFO_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_access" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "server_read" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_flush" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "xprt_recvs" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READLINK_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "WRITE_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSSTAT_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SETATTR_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SETATTR_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "GETATTR_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKNOD_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSSTAT_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSSTAT_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "CREATE_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "ACCESS_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LOOKUP_bytes_sent" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "ACCESS_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "PATHCONF_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKNOD_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LOOKUP_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "REMOVE_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LOOKUP_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSSTAT_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "COMMIT_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "short_read" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIR_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_readpage" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READ_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "FSINFO_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "vfs_release" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKDIR_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "CREATE_queue" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RMDIR_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SETATTR_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "RENAME_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "GETATTR_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIR_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "COMMIT_rtt" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "ACCESS_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKDIR_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LINK_ntrans" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "attr_invalidate" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LOOKUP_execute" : {
+                    "unit" : "ms/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LOOKUP_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "READDIRPLUS_ops" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "SYMLINK_bytes_recv" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "LINK_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "data_invalidate" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                },
+                "MKNOD_timeouts" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/self/mountstats",
+                    "source" : {
+                        "name" : "/proc/self/mountstats",
+                        "type" : "procfs"
+                    }
+                }
+            }
+        },
+        "sysv_shm" : {
+            "*" : {
+                "segs_used" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "procfs metric read from /proc/sysvipc/shm",
+                    "source" : {
+                        "name" : "/proc/sysvipc/shm",
+                        "type" : "procfs"
+                    }
+                },
+                "mem_used" : {
+                    "unit" : "B",
+                    "type" : "instant",
+                    "documentation" : "procfs metric read from /proc/sysvipc/shm",
+                    "source" : {
+                        "name" : "/proc/sysvipc/shm",
+                        "type" : "procfs"
+                    }
+                }
+            }
+        },
+        "intel_ivb_cbo" : {
+            "COUNTER0_OCCUPANCY" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LLC_LOOKUP_DATA_READ" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "RING_IV_USED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LLC_LOOKUP_WRITE" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "ib_ext" : {
+            "*" : {
+                "port_rcv_data" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                },
+                "port_xmit_pkts" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_xmit_data" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                },
+                "port_multicast_xmit_pkts" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_rcv_pkts" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_unicast_rcv_pkts" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_multicast_rcv_pkts" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_unicast_xmit_pkts" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                }
+            }
+        },
+        "intel_snb_qpi" : {
+            "G2_NCB_DATA" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "TxL_FLITS_G1_HOM" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "TxL_FLITS_G1_SNP" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "G1_DRS_DATA" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_ivb_pcu" : {
+            "MAX_POWER_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "MAX_TEMP_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "MIN_IO_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "MIN_SNOOP_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "C6_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "C3_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_snb" : {
+            "LOAD_OPS_ALL" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_OPS_LLC_HIT" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_OPS_L1_HIT" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "SSE_DOUBLE_PACKED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_L1D_ALL" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CLOCKS_UNHALTED_CORE" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CLOCKS_UNHALTED_REF" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "SSE_DOUBLE_SCALAR" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "SIMD_DOUBLE_256" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "INSTRUCTIONS_RETIRED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_OPS_L2_HIT" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "lnet" : {
+            "*" : {
+                "tx_bytes" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/sys/lnet/stats",
+                    "source" : {
+                        "name" : "/proc/sys/lnet/stats",
+                        "type" : "procfs"
+                    }
+                },
+                "rx_msgs_dropped" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/sys/lnet/stats",
+                    "source" : {
+                        "name" : "/proc/sys/lnet/stats",
+                        "type" : "procfs"
+                    }
+                },
+                "rx_msgs" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/sys/lnet/stats",
+                    "source" : {
+                        "name" : "/proc/sys/lnet/stats",
+                        "type" : "procfs"
+                    }
+                },
+                "tx_msgs" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/sys/lnet/stats",
+                    "source" : {
+                        "name" : "/proc/sys/lnet/stats",
+                        "type" : "procfs"
+                    }
+                },
+                "rx_bytes" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/sys/lnet/stats",
+                    "source" : {
+                        "name" : "/proc/sys/lnet/stats",
+                        "type" : "procfs"
+                    }
+                },
+                "rx_bytes_dropped" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/sys/lnet/stats",
+                    "source" : {
+                        "name" : "/proc/sys/lnet/stats",
+                        "type" : "procfs"
+                    }
+                }
+            }
+        },
+        "FLOPS" : {
+            "unit" : "ops/s",
+            "type" : "rate",
+            "documentation" : "Generated from the available FLOPS hardware counters present on the cores"
+        },
+        "FLOPS_SINGLE": {
+            "unit": "op/s",
+            "type": "rate",
+            "documentation": "Generated from the available Single Width FLOP hardware counters present on the cores"
+        },
+        "FLOPS_DOUBLE": {
+            "unit": "op/s",
+            "type": "rate",
+            "documentation": "Generated from the available Double Width FLOP hardware counters present on the cores"
+        },
+        "intel_8pmc3": {
+            "FP_ARITH_INST_RETIRED_SCALAR_DOUBLE": {
+                "unit" : "",
+                "type" : "instant",
+                "documentation" : "Number of scalar double precision floating point instructions retired. Each count represents 1 computation."
+            },
+            "FP_ARITH_INST_RETIRED_SCALAR_SINGLE": {
+                "unit" : "",
+                "type" : "instant",
+                "documentation" : "Number of scalar  single precision floating point instructions retired. Each count represents 1 computation."
+            },
+            "FP_ARITH_INST_RETIRED_128B_PACKED_DOUBLE": {
+                "unit" : "",
+                "type" : "instant",
+                "documentation" : "Number of 128-bit packed double precision floating point instructions retired. Each count represents 2 computations."
+            },
+            "FP_ARITH_INST_RETIRED_128B_PACKED_SINGLE": {
+                "unit" : "",
+                "type" : "instant",
+                "documentation" : "Number of 128-bit single precision floating point instructions retired. Each count represents 4 computations."
+            },
+            "FP_ARITH_INST_RETIRED_256B_PACKED_DOUBLE": {
+                "unit" : "",
+                "type" : "instant",
+                "documentation" : "Number of 256-bit double precision floating point instructions retired. Each count represents 4 computations."
+            },
+            "FP_ARITH_INST_RETIRED_256B_PACKED_SINGLE": {
+                "unit" : "",
+                "type" : "instant",
+                "documentation" : "Number of 256-bit single precision floating point instructions retired. Each count represents 8 computations."
+            },
+            "FP_ARITH_INST_RETIRED_512B_PACKED_DOUBLE": {
+                "unit" : "",
+                "type" : "instant",
+                "documentation" : "Number of 512-bit double precision floating point instructions retired. Each count represents 8 computations."
+            },
+            "FP_ARITH_INST_RETIRED_512B_PACKED_SINGLE": {
+                "unit" : "",
+                "type" : "instant",
+                "documentation" : "Number of 512-bit single precision floating point instructions retired. Each count represents 16 computations."
+            },
+            "CLOCKS_UNHALTED_REF": {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CLOCKS_UNHALTED_CORE": {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "INSTRUCTIONS_RETIRED": {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_skx_cha": {
+            "LLC_LOOKUP_WRITE": {
+                "unit": "",
+                "type": "instant"
+            },
+            "LLC_LOOKUP_DATA_READ_LOCAL": {
+                "unit": "",
+                "type": "instant"
+            },
+            "SF_EVICTIONS_MES": {
+                "unit": "",
+                "type": "instant"
+            },
+            "BYPASS_CHA_IMC_ALL": {
+                "unit": "",
+                "type": "instant"
+            }
+        },
+        "intel_skx_imc": {
+            "CAS_READS": {
+                "unit": "",
+                "type": "instant"
+            },
+            "CAS_WRITES": {
+                "unit": "",
+                "type" :"instant"
+            },
+            "ACT_COUNT": {
+                "unit": "",
+                "type": "instant"
+            },
+            "PRE_COUNT_MISS": {
+                "unit": "",
+                "type": "instant"
+            }
+        },
+        "tmpfs" : {
+            "*" : {
+                "files_used" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "syscall metric read from statfs",
+                    "source" : {
+                        "name" : "statfs",
+                        "type" : "syscall"
+                    }
+                },
+                "bytes_used" : {
+                    "unit" : "B",
+                    "type" : "instant",
+                    "documentation" : "syscall metric read from statfs",
+                    "source" : {
+                        "name" : "statfs",
+                        "type" : "syscall"
+                    }
+                }
+            }
+        },
+        "intel_rapl" : {
+            "*" : {
+                "MSR_DRAM_ENERGY_STATUS" : {
+                    "unit" : "mJ/s",
+                    "type" : "rate"
+                },
+                "MSR_PKG_ENERGY_STATUS" : {
+                    "unit" : "mJ/s",
+                    "type" : "rate"
+                },
+                "MSR_PP0_ENERGY_STATUS" : {
+                    "unit" : "mJ/s",
+                    "type" : "rate"
+                }
+            }
+        },
+        "intel_nhm" : {
+            "*" : {
+                "4391249" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "4392145" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "4391377" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "CLOCKS_UNHALTED_REF" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "INSTRUCTIONS_RETIRED" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "4395024" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "CLOCKS_UNHALTED_CORE" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "4423696" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "4391441" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "4391633" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "4424144" : {
+                    "unit" : "",
+                    "type" : "instant"
+                }
+            }
+        },
+        "intel_hsw_r2pci" : {
+            "CTR0" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR1" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR2" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR3" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_snb_hau" : {
+            "IMC_WRITES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "WRITE_REQUESTS" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CLOCKTICKS" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "READ_REQUESTS" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_snb_pcu" : {
+            "MAX_POWER_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "MAX_TEMP_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "MIN_IO_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "MIN_SNOOP_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "C6_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "C3_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_hsw_imc" : {
+            "FIXED_CTR" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR0" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR1" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR2" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR3" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_snb_imc" : {
+            "CAS_WRITES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "PRE_COUNT_MISS" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "ACT_COUNT" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CAS_READS" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "ps" : {
+            "*" : {
+                "nr_running" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "procfs metric read from /proc/loadavg",
+                    "source" : {
+                        "name" : "/proc/loadavg",
+                        "type" : "procfs"
+                    }
+                },
+                "ctxt" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/stat",
+                    "source" : {
+                        "name" : "/proc/stat",
+                        "type" : "procfs"
+                    }
+                },
+                "nr_threads" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "procfs metric read from /proc/loadavg",
+                    "source" : {
+                        "name" : "/proc/loadavg",
+                        "type" : "procfs"
+                    }
+                },
+                "load_15" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "procfs metric read from /proc/loadavg",
+                    "source" : {
+                        "name" : "/proc/loadavg",
+                        "type" : "procfs"
+                    }
+                },
+                "load_1" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "procfs metric read from /proc/loadavg",
+                    "source" : {
+                        "name" : "/proc/loadavg",
+                        "type" : "procfs"
+                    }
+                },
+                "load_5" : {
+                    "unit" : "",
+                    "type" : "instant",
+                    "documentation" : "procfs metric read from /proc/loadavg",
+                    "source" : {
+                        "name" : "/proc/loadavg",
+                        "type" : "procfs"
+                    }
+                },
+                "processes" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/stat",
+                    "source" : {
+                        "name" : "/proc/stat",
+                        "type" : "procfs"
+                    }
+                }
+            }
+        },
+        "ib_sw" : {
+            "*" : {
+                "rx_bytes" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "Average rate of bytes received by each compute node. The IB HCA/PORT statistics are obtained by querying the extended performance counters of the switch port to which the HCA/PORT is connected."
+                },
+                "tx_packets" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "Average rate of packets transmitted by each compute node. The IB HCA/PORT statistics are obtained by querying the extended performance counters of the switch port to which the HCA/PORT is connected."
+                },
+                "rx_packets" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "Average rate of packets received by each compute node. The IB HCA/PORT statistics are obtained by querying the extended performance counters of the switch port to which the HCA/PORT is connected."
+                },
+                "tx_bytes" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "Average rate of data transmitted by each compute node. The IB HCA/PORT statistics are obtained by querying the extended performance counters of the switch port to which the HCA/PORT is connected."
+                }
+            }
+        },
+        "intel_wtm" : {
+            "*" : {
+                "4391249" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "4392145" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "4391377" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "CLOCKS_UNHALTED_REF" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "INSTRUCTIONS_RETIRED" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "4395024" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "CLOCKS_UNHALTED_CORE" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "4423696" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "4391441" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "4391633" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "4424144" : {
+                    "unit" : "",
+                    "type" : "instant"
+                }
+            }
+        },
+        "ib" : {
+            "*" : {
+                "port_xmit_discards" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_rcv_switch_relay_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "symbol_error" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "VL15_dropped" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "link_downed" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "excessive_buffer_overrun_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_rcv_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "local_link_integrity_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_xmit_wait" : {
+                    "unit" : "ms/s",
+                    "type" : "rate"
+                },
+                "port_xmit_packets" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_rcv_remote_physical_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_xmit_constraint_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_rcv_packets" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_xmit_data" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                },
+                "port_rcv_constraint_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "link_error_recovery" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "port_rcv_data" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                }
+            }
+        },
+        "osc" : {
+            "*" : {
+                "wait" : {
+                    "unit" : "us/s",
+                    "type" : "rate"
+                },
+                "read_bytes" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                },
+                "ost_statfs" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "write_bytes" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                },
+                "ost_setattr" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "reqs" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "ost_punch" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "ost_destroy" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "ost_read" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "ost_write" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                }
+            }
+        },
+        "intel_hsw_pcu" : {
+            "0" : {
+                "unit" : "",
+                "type" : "instant"
+            },
+            "C3_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "C6_CYCLES" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "cpicore" : {
+            "unit" : "1",
+            "type" : "ratio",
+            "documentation" : "Number of clock ticks per instruction using the core CPU clock."
+        },
+        "cpiref" : {
+            "unit" : "1",
+            "type" : "ratio",
+            "documentation" : "Number of reference clock ticks per instruction"
+        },
+        "mdc" : {
+            "*" : {
+                "wait" : {
+                    "unit" : "us/s",
+                    "type" : "rate"
+                },
+                "mds_getattr_lock" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "mds_sync" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "mds_getattr" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "mds_close" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "reqs" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "ldlm_cancel" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "mds_getxattr" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "mds_readpage" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "mds_statfs" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                }
+            }
+        },
+        "Error" : {
+            "type" : "metadata",
+            "documentation" : "List of the processing errors encountered during job summary creation"
+        },
+        "intel_snb_r2pci" : {
+            "ACKNOWLEDGED_USED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "ADDRESS_USED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "TRANSMITS" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "DATA_USED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "vm" : {
+            "*" : {
+                "pgfree" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "kswapd_inodesteal" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgrefill_normal" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "slabs_scanned" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgactivate" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pswpin" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgmajfault" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pageoutrun" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgpgin" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgdeactivate" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgscan_kswapd_normal" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "kswapd_steal" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pswpout" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgsteal_normal" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgfault" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgpgout" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pginodesteal" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgscan_direct_normal" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgrotated" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "pgalloc_normal" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                },
+                "allocstall" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/vmstat",
+                    "source" : {
+                        "name" : "/proc/vmstat",
+                        "type" : "procfs"
+                    }
+                }
+            }
+        },
+        "intel_hsw_qpi" : {
+            "CTR0" : {
+                "unit" : "flt/s",
+                "type" : "rate"
+            },
+            "CTR1" : {
+                "unit" : "flt/s",
+                "type" : "rate"
+            },
+            "CTR2" : {
+                "unit" : "flt/s",
+                "type" : "rate"
+            },
+            "CTR3" : {
+                "unit" : "flt/s",
+                "type" : "rate"
+            }
+        },
+        "intel_hsw_cbo" : {
+            "0" : {
+                "unit" : "",
+                "type" : "instant"
+            }
+        },
+        "cpldref" : {
+            "unit" : "1",
+            "type" : "ratio",
+            "documentation" : "Number of clock ticks per L1D cache load using the reference CPU clock."
+        },
+        "amd64_sock" : {
+            "*" : {
+                "HT0" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                },
+                "HT1" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                },
+                "HT2" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                },
+                "DRAM" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                }
+            }
+        },
+        "amd64_core" : {
+            "*" : {
+                "SSE_FLOPS" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "USER" : {
+                    "unit" : "/s",
+                    "type" : "rate"
+                },
+                "DCSF" : {
+                    "unit" : "B/s",
+                    "type" : "rate"
+                }
+            }
+        },
+        "mic" : {
+            "*" : {
+                "nice_sum" : {
+                    "unit" : "cs/s",
+                    "type" : "rate"
+                },
+                "idle_sum" : {
+                    "unit" : "cs/s",
+                    "type" : "rate"
+                },
+                "user_sum" : {
+                    "unit" : "cs/s",
+                    "type" : "rate"
+                },
+                "jiffy_counter" : {
+                    "unit" : "cs/s",
+                    "type" : "rate"
+                },
+                "sys_sum" : {
+                    "unit" : "cs/s",
+                    "type" : "rate"
+                }
+            }
+        },
+        "intel_ivb_imc" : {
+            "FIXED_CTR" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR0" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR1" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR2" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR3" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_hsw" : {
+            "LOAD_OPS_ALL" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_OPS_LLC_HIT" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_OPS_L1_HIT" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "SSE_DOUBLE_PACKED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_L1D_ALL" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CLOCKS_UNHALTED_CORE" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CLOCKS_UNHALTED_REF" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "SSE_DOUBLE_SCALAR" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "SIMD_DOUBLE_256" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "INSTRUCTIONS_RETIRED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LOAD_OPS_L2_HIT" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "nHosts" : {
+            "unit" : "1",
+            "type" : "discrete",
+            "documentation" : "Number of hosts with raw data"
+        },
+        "intel_hsw_hau" : {
+            "CTR0" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR1" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR2" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR3" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_ivb_r2pci" : {
+            "CTR0" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR1" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR2" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "CTR3" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "net" : {
+            "*" : {
+                "tx_compressed" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "multicast" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "tx_heartbeat_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "tx_fifo_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_fifo_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "tx_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "tx_dropped" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "tx_packets" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "collisions" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "tx_carrier_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_compressed" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "tx_aborted_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "tx_window_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_over_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_packets" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_length_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_missed_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "tx_bytes" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_frame_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_dropped" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_crc_errors" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                },
+                "rx_bytes" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "sysfs metric read from /sys/class/net/*/statistics",
+                    "source" : {
+                        "name" : "/sys/class/net/*/statistics",
+                        "type" : "sysfs"
+                    }
+                }
+            }
+        },
+        "proc" : {
+            "*" : {
+                "VmSwap" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                },
+                "VmRSS" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                },
+                "VmLib" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                },
+                "VmPTE" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                },
+                "Cpus_allowed_list" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "Threads" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "VmLck" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                },
+                "VmHWM" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                },
+                "VmExe" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                },
+                "VmStk" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                },
+                "Uid" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "Mems_allowed_list" : {
+                    "unit" : "",
+                    "type" : "instant"
+                },
+                "VmPeak" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                },
+                "VmData" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                },
+                "VmSize" : {
+                    "unit" : "kB",
+                    "type" : "instant"
+                }
+            }
+        },
+        "llite" : {
+            "*" : {
+                "create" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "mknod" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "seek" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "getattr" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "direct_read" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "mkdir" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "removexattr" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "mmap" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "listxattr" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "osc_write" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "open" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "rename" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "osc_read" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "direct_write" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "readdir" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "setxattr" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "read_bytes" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "close" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "flock" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "lookup" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "rmdir" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "dirty_pages_misses" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "truncate" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "getxattr" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "dirty_pages_hits" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "inode_permission" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "ioctl" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "link" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "symlink" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "unlink" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "write_bytes" : {
+                    "unit" : "B/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "alloc_inode" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "setattr" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "fsync" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                },
+                "statfs" : {
+                    "unit" : "/s",
+                    "type" : "rate",
+                    "documentation" : "procfs metric read from /proc/fs/lustre/llite",
+                    "source" : {
+                        "name" : "/proc/fs/lustre/llite",
+                        "type" : "procfs"
+                    }
+                }
+            }
+        },
+        "intel_snb_cbo" : {
+            "COUNTER0_OCCUPANCY" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LLC_LOOKUP_DATA_READ" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "RING_IV_USED" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "LLC_LOOKUP_WRITE" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        },
+        "intel_ivb_qpi" : {
+            "*" : {
+                "CTR0" : {
+                    "unit" : "flt/s",
+                    "type" : "rate"
+                },
+                "CTR1" : {
+                    "unit" : "flt/s",
+                    "type" : "rate"
+                },
+                "CTR2" : {
+                    "unit" : "flt/s",
+                    "type" : "rate"
+                },
+                "CTR3" : {
+                    "unit" : "flt/s",
+                    "type" : "rate"
+                }
+            }
+        },
+        "complete" : {
+            "type" : "metadata",
+            "documentation" : "Whether the raw data was available for all nodes that the job was assigned"
+        },
+        "mem" : {
+            "HugePages_Total" : {
+                "unit" : "",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "Inactive" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "MemFree" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "Bounce" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "HugePages_Free" : {
+                "unit" : "",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "AnonPages" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "FilePages" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "MemTotal" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "Writeback" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "PageTables" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "Dirty" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "NFS_Unstable" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "Mapped" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "Active" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "used_minus_diskcache" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "Memory usage excluding the kernel SLAB cache and buffer cache."
+            },
+            "MemUsed" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            },
+            "Slab" : {
+                "unit" : "B",
+                "type" : "instant",
+                "documentation" : "sysfs metric read from /sys/devices/system/node/node*/meminfo",
+                "source" : {
+                    "name" : "/sys/devices/system/node/node*/meminfo",
+                    "type" : "sysfs"
+                }
+            }
+        },
+        "intel_uncore" : {
+            "FIXED_CTR0" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "PMC0" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "PMC1" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "PMC2" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "PMC3" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "PMC4" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "PMC5" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "PMC6" : {
+                "unit" : "/s",
+                "type" : "rate"
+            },
+            "PMC7" : {
+                "unit" : "/s",
+                "type" : "rate"
+            }
+        }
+    }
+};
 
+
+db.schema.update({_id: summarydef._id}, summarydef, {upsert: true})
+db.schema.update({_id: summaryDef0938._id}, summaryDef0938, {upsert: true})
+
+db.schema.update({_id: sdef._id}, sdef, {upsert: true})

--- a/pickler/account.py
+++ b/pickler/account.py
@@ -195,9 +195,9 @@ class DbAcct(object):
 
             # Make sure to filter on the size of jobs we're supposed to be processing.
             if self.small_jobs:
-                query += "WHERE l3.nodes * l3.hours <= 10000"
+                query += "WHERE l3.hours <= 24"
             elif self.large_jobs:
-                query += "WHERE l3.nodes * l3.hours > 10000"
+                query += "WHERE l3.hours > 24"
 
             # Make sure to maintain the original ordering.
             query += "ORDER BY l3.end_time_ts"

--- a/pickler/account.py
+++ b/pickler/account.py
@@ -135,9 +135,9 @@ class DbAcct(object):
             query += " ORDER BY end_time_ts ASC"
             return query, data
         else:
-            # We're going to be dealing with [small|large]_jobs, "small_jobs" are defined as having less then
-            # 10000 node hours while large jobs are > 10000 node hours. Since we need to be able to filter on node hours
-            # our sql is going to be slightly more complicated.
+            # We're going to be dealing with [small|large]_jobs, "small_jobs" are defined as jobs that ran < 24 hrs and
+            # have less then 200 nodes while large jobs are defined as any job that has run over 24 hours. Since we need 
+            # to be able to filter on nodes and wall time the sql is slightly more complicated.
 
             # This query is used to select the initial set of data from accountfact
             initial_data_query = """

--- a/pickler/account.py
+++ b/pickler/account.py
@@ -195,7 +195,7 @@ class DbAcct(object):
 
             # Make sure to filter on the size of jobs we're supposed to be processing.
             if self.small_jobs:
-                query += "WHERE l3.hours <= 24 "
+                query += "WHERE l3.hours <= 24 AND l3.nodes < 200"
             elif self.large_jobs:
                 query += "WHERE l3.hours > 24 "
 

--- a/pickler/account.py
+++ b/pickler/account.py
@@ -151,7 +151,7 @@ class DbAcct(object):
                                          AND af.resource_id = %s
                 """.format(self.tablename)
 
-            data = (self.resource_id, self.process_version)
+            data = (self.process_version, self.resource_id)
             if start_time is not None:
                 initial_data_query += " \t\t\t\t\t\t AND af.end_time_ts >= %s "
                 data = data + (start_time,)

--- a/pickler/account.py
+++ b/pickler/account.py
@@ -195,7 +195,7 @@ class DbAcct(object):
 
             # Make sure to filter on the size of jobs we're supposed to be processing.
             if self.small_jobs:
-                query += "WHERE l3.hours <= 24 AND l3.nodes < 200"
+                query += "WHERE l3.hours <= 24 AND l3.nodes < 200 "
             elif self.large_jobs:
                 query += "WHERE l3.hours > 24 "
 

--- a/pickler/account.py
+++ b/pickler/account.py
@@ -195,9 +195,9 @@ class DbAcct(object):
 
             # Make sure to filter on the size of jobs we're supposed to be processing.
             if self.small_jobs:
-                query += "WHERE l3.hours <= 24"
+                query += "WHERE l3.hours <= 24 "
             elif self.large_jobs:
-                query += "WHERE l3.hours > 24"
+                query += "WHERE l3.hours > 24 "
 
             # Make sure to maintain the original ordering.
             query += "ORDER BY l3.end_time_ts"

--- a/pickler/batch_acct.py
+++ b/pickler/batch_acct.py
@@ -322,7 +322,7 @@ class SLURMNativeAcct(BatchAcct):
                 if '-' in n:
                     num = n.split('-')
                     for x in range(int(num[0]), int(num[1])+1):
-                        host_list_expanded.append(node_head + str("%02d" % x))
+                        host_list_expanded.append(node_head + str("%03d" % x))
                 else:
                     host_list_expanded.append(node_head + n)
         else:
@@ -338,7 +338,7 @@ class SLURMNativeAcct(BatchAcct):
           yield a
 
 
-class OpenXDMoDSlurm(BatchAcct):
+class OpenXDMoDSlurm(SLURMNativeAcct):
   """ Process accounting data produced by the sacct command with the following """
   """ flags. """
   """ TZ=UTC sacct --clusters *cluster* --allusers \ """
@@ -348,7 +348,6 @@ class OpenXDMoDSlurm(BatchAcct):
   """          ncpus,reqcpus,reqmem,reqgres,reqtres,timelimit,nodelist,jobname \ """
   """  --state CANCELLED,COMPLETED,FAILED,NODE_FAIL,PREEMPTED,TIMEOUT"""
   def __init__(self,acct_file,host_name_ext):
-
     self.timeconverter = TimeFixer('UTC', True)
 
     self.fields = (
@@ -380,6 +379,8 @@ class OpenXDMoDSlurm(BatchAcct):
     )
 
     BatchAcct.__init__(self,'SLURM',acct_file,host_name_ext,"|")
+
+
 
 class SLURMNative2Acct(SLURMNativeAcct):
   """ Process accounting data produced by the sacct command used by tacc_stats """

--- a/pickler/indexarchives.py
+++ b/pickler/indexarchives.py
@@ -139,8 +139,11 @@ class BasicTaccArchiveParser(object):
         """ open and parse the contents of the archive """
 
         self.fileline = 0
-
-        with gzip.open(self.filepath) as filep:
+        if self.filepath.endswith('.gz'): 
+            open_func=gzip.open
+        else: 
+            open_func=open
+        with open_func(self.filepath) as filep:
             for line in filep:
                 self.fileline += 1
                 self.parseline(line.strip())
@@ -164,7 +167,6 @@ class TaccStatsArchiveProcessor(object):
             hostname = data.hostname
             if self.hostnameext != "" and (not hostname.endswith(self.hostnameext)):
                 hostname += "." + self.hostnameext
-
             if data.firsttimestamp != None:
                 self.dbac.insert(hostname, archive, data.firsttimestamp, data.lasttimestamp, data.tacc_version)
             else:
@@ -269,7 +271,7 @@ class TaccStatsArchiveFinder(object):
             dirpath = os.path.join(topdir, hostname)
             for taccfile in os.listdir(dirpath):
                 archivefile = os.path.join(dirpath, taccfile)
-                if taccfile.endswith(".gz") and self.filenameok(taccfile):
+                if self.filenameok(taccfile):
                     yield archivefile
 
             hostcount += 1

--- a/pickler/job_stats.py
+++ b/pickler/job_stats.py
@@ -544,7 +544,6 @@ class Host(object):
         return self.stats[type_name][dev_name][:, index]
 
 
-
 class Job(object):
     # TODO errors/comments
     __slots__ = ('id', 'start_time', 'end_time', 'acct', 'schemas', 'hosts',

--- a/pickler/job_stats.py
+++ b/pickler/job_stats.py
@@ -852,34 +852,6 @@ class OpenXDMoDJob(Job):
 
     """
 
-    def get_stats_paths(self):
-        raw_host_stats_dir = os.path.join(self.raw_stats_dir, self.name+self.name_ext)
-        job_start = self.job.start_time - RAW_STATS_TIME_PAD
-        job_end = self.job.end_time + RAW_STATS_TIME_PAD
-        path_list = []
-        try:
-            for ent in os.listdir(raw_host_stats_dir):
-                base, dot, ext = ent.partition(".") if '.' in ent else (ent, '.', 'gz')
-                if not base.isdigit():
-                    continue
-                if ext != "gz":
-                    continue
-                # Support for filenames of the form %Y%m%d
-                if re.match('^[0-9]{4}[0-1][0-9][0-3][0-9]$', base):
-                    base = (datetime.datetime.strptime(base,"%Y%m%d") - datetime.datetime(1970,1,1)).total_seconds()
-                # Prune to files that might overlap with job.
-                ent_start = long(base)
-                ent_end = ent_start + 2*RAW_STATS_TIME_MAX
-                if ((ent_start <= job_start) and (job_start <= ent_end)) or ((ent_start <= job_end) and (job_end <= ent_end)) or (max(job_start, ent_start) <= min(job_end, ent_end)) :
-                    full_path = os.path.join(raw_host_stats_dir, ent)
-                    path_list.append((full_path, ent_start))
-                    self.trace("path `%s', start %d", full_path, ent_start)
-        except Exception as exc:
-            logging.error("get_stats_paths job %s. %s", self.job.id, exc)
-
-        path_list.sort(key=lambda tup: tup[1])
-        return path_list
-
     def gather_stats(self):
         host_list = []
 
@@ -911,6 +883,33 @@ class OpenXDMoDJob(Job):
 
 
 class OpenXDMoDHost(Host):
+    def get_stats_paths(self):
+        raw_host_stats_dir = os.path.join(self.raw_stats_dir, self.name+self.name_ext)
+        job_start = self.job.start_time - RAW_STATS_TIME_PAD
+        job_end = self.job.end_time + RAW_STATS_TIME_PAD
+        path_list = []
+        try:
+            for ent in os.listdir(raw_host_stats_dir):
+                base, dot, ext = ent.partition(".") if '.' in ent else (ent, '.', 'gz')
+                if not base.isdigit():
+                    continue
+                if ext != "gz":
+                    continue
+                # Support for filenames of the form %Y%m%d
+                if re.match('^[0-9]{4}[0-1][0-9][0-3][0-9]$', base):
+                    base = (datetime.datetime.strptime(base,"%Y%m%d") - datetime.datetime(1970,1,1)).total_seconds()
+                # Prune to files that might overlap with job.
+                ent_start = long(base)
+                ent_end = ent_start + 2*RAW_STATS_TIME_MAX
+                if ((ent_start <= job_start) and (job_start <= ent_end)) or ((ent_start <= job_end) and (job_end <= ent_end)) or (max(job_start, ent_start) <= min(job_end, ent_end)) :
+                    full_path = os.path.join(raw_host_stats_dir, ent)
+                    path_list.append((full_path, ent_start))
+                    self.trace("path `%s', start %d", full_path, ent_start)
+        except Exception as exc:
+            logging.error("get_stats_paths job %s. %s", self.job.id, exc)
+
+        path_list.sort(key=lambda tup: tup[1])
+        return path_list
 
     def gather_stats(self):
         path_list = self.get_stats_paths()

--- a/pickler/job_stats.py
+++ b/pickler/job_stats.py
@@ -544,6 +544,7 @@ class Host(object):
         return self.stats[type_name][dev_name][:, index]
 
 
+
 class Job(object):
     # TODO errors/comments
     __slots__ = ('id', 'start_time', 'end_time', 'acct', 'schemas', 'hosts',
@@ -822,12 +823,15 @@ class Job(object):
         return host_stats
 
 
-def from_acct(acct, stats_home, host_list_dir, batch_acct):
+def from_acct(acct, stats_home, host_list_dir, batch_acct, open_xdmod=False):
     """from_acct(acct, stats_home)
     Return a Job object constructed from the appropriate accounting data acct using
     stats_home as the base directory, running all required processing.
     """
-    job = Job(acct, stats_home, host_list_dir, batch_acct)
+    if open_xdmod:
+        job = OpenXDMoDJob(acct, stats_home, host_list_dir, batch_acct)
+    else:
+        job = Job(acct, stats_home, host_list_dir, batch_acct)
     job.gather_stats() and job.munge_times() and job.process_stats()
     return job
 
@@ -842,8 +846,86 @@ def from_id(id, **kwargs):
     else:
         return None
 
-# if True:
-#     t0 = time.time()
-#     j = job_stats.from_id(2294341)
-#     t1 = time.time()
-#     print t1 - t0
+
+class OpenXDMoDJob(Job):
+    """
+
+    """
+
+    def get_stats_paths(self):
+        raw_host_stats_dir = os.path.join(self.raw_stats_dir, self.name+self.name_ext)
+        job_start = self.job.start_time - RAW_STATS_TIME_PAD
+        job_end = self.job.end_time + RAW_STATS_TIME_PAD
+        path_list = []
+        try:
+            for ent in os.listdir(raw_host_stats_dir):
+                base, dot, ext = ent.partition(".") if '.' in ent else (ent, '.', 'gz')
+                if not base.isdigit():
+                    continue
+                if ext != "gz":
+                    continue
+                # Support for filenames of the form %Y%m%d
+                if re.match('^[0-9]{4}[0-1][0-9][0-3][0-9]$', base):
+                    base = (datetime.datetime.strptime(base,"%Y%m%d") - datetime.datetime(1970,1,1)).total_seconds()
+                # Prune to files that might overlap with job.
+                ent_start = long(base)
+                ent_end = ent_start + 2*RAW_STATS_TIME_MAX
+                if ((ent_start <= job_start) and (job_start <= ent_end)) or ((ent_start <= job_end) and (job_end <= ent_end)) or (max(job_start, ent_start) <= min(job_end, ent_end)) :
+                    full_path = os.path.join(raw_host_stats_dir, ent)
+                    path_list.append((full_path, ent_start))
+                    self.trace("path `%s', start %d", full_path, ent_start)
+        except Exception as exc:
+            logging.error("get_stats_paths job %s. %s", self.job.id, exc)
+
+        path_list.sort(key=lambda tup: tup[1])
+        return path_list
+
+    def gather_stats(self):
+        host_list = []
+
+        if "host_list" in self.acct:
+            host_list = self.acct['host_list']
+            if host_list == ["None assigned"]:
+                host_list = []
+
+        if len(host_list) == 0 and self.end_time - self.start_time > 0:
+            self.error("empty host list")
+            return False
+
+        for hidx, host_name in enumerate(host_list):
+            # TODO Keep bad_hosts.
+            try:
+                host_name = host_name.split('.')[0]
+            except:
+                pass
+
+            host = OpenXDMoDHost(self, host_name, self.stats_home + '/archive', self.batch_acct.name_ext, hidx == 0)
+
+            if host.gather_stats():
+                self.hosts[host_name] = host
+
+        if not self.hosts:
+            self.error("no good hosts")
+            return False
+        return True
+
+
+class OpenXDMoDHost(Host):
+
+    def gather_stats(self):
+        path_list = self.get_stats_paths()
+        if len(path_list) == 0:
+            self.error("no stats files overlapping job")
+            return False
+
+        # read_stats_file() and parse_stats() append stats records
+        # into lists of tuples in self.raw_stats.  The lists will be
+        # converted into numpy arrays below.
+        for path, start_time in path_list:
+            try:
+                with open(path) as file:
+                    self.read_stats_file(file)
+            except IOError as ioe:
+                self.error("read error for file %s", path)
+
+        return self.raw_stats

--- a/pickler/output.py
+++ b/pickler/output.py
@@ -2,6 +2,7 @@
 """ job summary output """
 import json
 import logging
+from urllib import quote_plus
 from pymongo import MongoClient
 from pymongo.errors import InvalidDocument
 
@@ -26,7 +27,17 @@ class StdoutOutput(object):
 
 class MongoOutput(object):
     def __init__(self, dbconfig):
-        self.client = MongoClient(dbconfig['uri'])
+        if 'uri' in dbconfig:
+            uri = dbconfig['uri']
+        else:
+            uri = "mongodb://%s:%s@%s/%s?authSource=%s" % (
+                quote_plus(dbconfig['user']),
+                quote_plus(dbconfig['password']),
+                quote_plus(dbconfig['host']),
+                quote_plus(dbconfig['dbname']),
+                quote_plus(dbconfig['authSource'])
+            )
+        self.client = MongoClient(uri)
         self.db = self.client[dbconfig['dbname']]
 
     def insert(self, resourcename, summary, timeseries):

--- a/pickler/output.py
+++ b/pickler/output.py
@@ -39,6 +39,8 @@ class MongoOutput(object):
         except InvalidDocument as exc:
             logging.error("inserting summary document %s %s. %s",
                           resourcename, summary["_id"], str(exc))
+        except Exception as e:
+            logging.error("Unhandled Error %s", str(e))
 
         timeseriesOk = False
         if timeseries != None:

--- a/pickler/process.py
+++ b/pickler/process.py
@@ -211,7 +211,7 @@ def getoptions():
         "small_jobs": False
     }
 
-    opts, args = getopt(sys.argv[1:], "r:l:c:dqgsho", ["resource=", "logfile=", "localjobid=", "config=", "debug", "quiet", "large", "small", "help"])
+    opts, args = getopt(sys.argv[1:], "r:l:c:dqgsh", ["resource=", "logfile=", "localjobid=", "config=", "debug", "quiet", "large", "small", "help"])
 
     for opt in opts:
         if opt[0] in ("-r", "--resource"):

--- a/pickler/process.py
+++ b/pickler/process.py
@@ -6,7 +6,6 @@ import account
 import summarize
 import sys
 import time
-import datetime
 from multiprocessing import Process
 import socket
 from getopt import getopt
@@ -19,6 +18,7 @@ from journal import Journal
 
 PROCESS_VERSION = 4
 ERROR_INCOMPLETE = -1001
+
 
 class RateCalculator:
     def __init__(self, procid):
@@ -199,6 +199,7 @@ def usage():
     print "  -q --quiet            only log errors"
     print "  -h --help             print this help message"
 
+
 def getoptions():
     """ process comandline options """
 
@@ -243,6 +244,7 @@ def getoptions():
 
     return retdata
 
+
 def main():
 
     warnings.filterwarnings("ignore", "Degrees of freedom <= 0 for slice", RuntimeWarning)
@@ -273,5 +275,6 @@ def main():
 
     sys.exit(exit_code)
 
-if __name__ == '__main__': 
+
+if __name__ == '__main__':
     main()

--- a/pickler/process.py
+++ b/pickler/process.py
@@ -207,8 +207,7 @@ def getoptions():
         "logfile": None,
         "resource": None,
         "localjobid": None,
-        "config": None,
-        "open_xdmod": False
+        "config": None
     }
 
     opts, args = getopt(sys.argv[1:], "r:l:c:dqho", ["resource=", "logfile=", "localjobid=", "config=", "debug", "quiet", "help", "open_xdmod"])

--- a/pickler/process.py
+++ b/pickler/process.py
@@ -213,7 +213,7 @@ def getoptions():
         "small_jobs": False
     }
 
-    opts, args = getopt(sys.argv[1:], "r:l:c:dqgsho", ["resource=", "logfile=", "localjobid=", "config=", "debug", "quiet", "help", "open_xdmod"])
+    opts, args = getopt(sys.argv[1:], "r:l:c:dqgsho", ["resource=", "logfile=", "localjobid=", "config=", "debug", "quiet", "large", "small", "help", "open_xdmod"])
 
     for opt in opts:
         if opt[0] in ("-r", "--resource"):

--- a/pickler/process.py
+++ b/pickler/process.py
@@ -124,7 +124,7 @@ def createsummary(options, totalprocs, procid):
 
         processtimes = { "mintime": 2**64, "maxtime": 0 }
 
-        dbreader = account.DbAcct( settings['resource_id'], dbconf, PROCESS_VERSION, totalprocs, procid, options['localjobid'], options['large_jobs'])
+        dbreader = account.DbAcct( settings['resource_id'], dbconf, PROCESS_VERSION, totalprocs, procid, options['localjobid'], options['large_jobs'], options['small_jobs'])
 
         bacct = batch_acct.factory(settings['batch_system'], settings['acct_path'], settings['host_name_ext'] )
 

--- a/pickler/process.py
+++ b/pickler/process.py
@@ -103,8 +103,6 @@ def createsummary(options, totalprocs, procid):
 
     referencetime = int(time.time()) - ( 7 * 24 * 3600 ) 
 
-    is_open_xdmod = options['open_xdmod']
-
     config = account.getconfig(options['config'])
     dbconf = config['accountdatabase']
 
@@ -138,7 +136,7 @@ def createsummary(options, totalprocs, procid):
         for acct in dbreader.reader():
             logging.debug("%s local_job_id = %s", resourcename, acct['id'])
             acct['host_list'] = construct_host_list(acct)
-            job = job_stats.from_acct( acct, settings['tacc_stats_home'], settings['host_list_dir'] if 'host_list_dir' in settings else None, bacct, is_open_xdmod)
+            job = job_stats.from_acct( acct, settings['tacc_stats_home'], settings['host_list_dir'] if 'host_list_dir' in settings else None, bacct)
             summary,timeseries = summarize.summarize(job, lariat)
 
             insertOk = outdb.insert(resourcename, summary, timeseries)
@@ -213,7 +211,7 @@ def getoptions():
         "small_jobs": False
     }
 
-    opts, args = getopt(sys.argv[1:], "r:l:c:dqgsho", ["resource=", "logfile=", "localjobid=", "config=", "debug", "quiet", "large", "small", "help", "open_xdmod"])
+    opts, args = getopt(sys.argv[1:], "r:l:c:dqgsho", ["resource=", "logfile=", "localjobid=", "config=", "debug", "quiet", "large", "small", "help"])
 
     for opt in opts:
         if opt[0] in ("-r", "--resource"):
@@ -232,8 +230,6 @@ def getoptions():
             retdata["small_jobs"] = True
         elif opt[0] in ("-c", "--config"):
             retdata['config'] = opt[1]
-        elif opt[0] in ("-o", "--openxdmod"):
-            retdata['open_xdmod'] = True
         elif opt[0] in ("-h", "--help"):
             usage()
             sys.exit(0)

--- a/pickler/process.py
+++ b/pickler/process.py
@@ -124,7 +124,7 @@ def createsummary(options, totalprocs, procid):
 
         processtimes = { "mintime": 2**64, "maxtime": 0 }
 
-        dbreader = account.DbAcct( settings['resource_id'], dbconf, PROCESS_VERSION, totalprocs, procid, options['localjobid'])
+        dbreader = account.DbAcct( settings['resource_id'], dbconf, PROCESS_VERSION, totalprocs, procid, options['localjobid'], options['large_jobs'])
 
         bacct = batch_acct.factory(settings['batch_system'], settings['acct_path'], settings['host_name_ext'] )
 
@@ -207,10 +207,12 @@ def getoptions():
         "logfile": None,
         "resource": None,
         "localjobid": None,
-        "config": None
+        "config": None,
+        "large_jobs": False,
+        "small_jobs": False
     }
 
-    opts, args = getopt(sys.argv[1:], "r:l:c:dqho", ["resource=", "logfile=", "localjobid=", "config=", "debug", "quiet", "help", "open_xdmod"])
+    opts, args = getopt(sys.argv[1:], "r:l:c:dqgsho", ["resource=", "logfile=", "localjobid=", "config=", "debug", "quiet", "help", "open_xdmod"])
 
     for opt in opts:
         if opt[0] in ("-r", "--resource"):
@@ -223,6 +225,10 @@ def getoptions():
             retdata['logfile'] = opt[1]
         elif opt[0] in ("-q", "--quiet"):
             retdata['log'] = logging.ERROR
+        elif opt[0] in ("-g", "--large_jobs"):
+            retdata["large_jobs"] = True
+        elif opt[0] in ("-s", "--small-jobs"):
+            retdata["small_jobs"] = True
         elif opt[0] in ("-c", "--config"):
             retdata['config'] = opt[1]
         elif opt[0] in ("-o", "--openxdmod"):
@@ -242,6 +248,8 @@ def main():
     warnings.filterwarnings("ignore", "Degrees of freedom <= 0 for slice", RuntimeWarning)
 
     options = getoptions()
+    if options['small_jobs'] and options['large_jobs']:
+        raise Exception('You can may only specify either small_jobs or large_jobs, not both.')
 
     setuplogger(options['log'], options['logfile'], logging.INFO)
 

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -422,7 +422,7 @@ def getperinterfacemetrics():
                      "intel_ivb_pcu",
                      "intel_ivb_r2pci",
              "intel_8pmc3",
-             "intel_4pmc3"
+             "intel_4pmc3",
              "intel_skx_cha"]
 
 

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -418,6 +418,24 @@ def getperinterfacemetrics():
                      "intel_ivb_pcu",
                      "intel_ivb_r2pci"]
 
+
+def fix_unicode(value):
+    if type(value) == unicode:
+        return value.encode('ascii', 'ignore')
+    elif type(value) == dict:
+        temp = {}
+        for k, v in value.iteritems():
+            temp[k.encode('ascii', 'ignore')] = fix_unicode(v)
+        return temp
+    elif type(value) == list:
+        temp = []
+        for i in value:
+            temp.append(fix_unicode(i))
+        return temp
+    else:
+        return value
+
+
 def summarize(j, lariatcache):
 
     summaryDict = {}
@@ -784,12 +802,12 @@ def summarize(j, lariatcache):
     # add hosts
     summaryDict['hosts'] = []
     for i in j.hosts.keys():
-        summaryDict['hosts'].append(i)
+        summaryDict['hosts'].append(i.encode('ascii', 'ignore') if type(i) == unicode else i)
 
     summaryDict['collection_sw'] = "tacc_stats " + " ".join(tacc_version)
 
     # add account info from slurm accounting files
-    summaryDict['acct'] = j.acct
+    summaryDict['acct'] = fix_unicode(j.acct)
 
     # add schema outline
     if statsOk and not COMPACT_OUTPUT:

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -16,7 +16,7 @@ import logging
 
 from timeseriessummary import TimeSeriesSummary
 
-SUMMARY_VERSION = "0.9.37"
+SUMMARY_VERSION = "0.9.38"
 
 VERBOSE = False
 

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -420,7 +420,9 @@ def getperinterfacemetrics():
                      "intel_ivb_hau",
                      "intel_ivb_imc",
                      "intel_ivb_pcu",
-                     "intel_ivb_r2pci"]
+                     "intel_ivb_r2pci",
+             "intel_8pmc3",
+             "intel_4pmc3"]
 
 
 def fix_unicode(value):

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -294,7 +294,9 @@ class LariatManager:
 def calculate_stats(v):
     res = { }
 
-    if len(v) > 0:
+    v = numpy.nan_to_num(v)
+
+    if v is not None and len(v) > 0:
 
         try:
             (

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -658,7 +658,6 @@ def summarize(j, lariatcache):
                 elif metricname == "intel_4pmc3" or metricname == 'intel_8pmc3':
                     compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_CORE', 'INSTRUCTIONS_RETIRED', corederived["cpicore"])
                     compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'INSTRUCTIONS_RETIRED', corederived["cpiref"])
-                    compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'LOAD_L1D_ALL', corederived["cpldref"])
 
                 elif metricname == "intel_snb_imc" or metricname == "intel_skx_imc" or metricname == "intel_hsw_imc" or metricname == "intel_ivb_imc" or metricname == "intel_knl_mc_dclk":
                     if metricname not in j.overflows:
@@ -780,6 +779,45 @@ def summarize(j, lariatcache):
 
         # TODO Nehalem/Westmere flops
 
+        # New Cascade Lake flop calculations
+        if 'intel_8pmc3' in totals.keys():
+            flops = single_flops = double_flops = 0.0
+            if 'FP_ARITH_INST_RETIRED_SCALAR_DOUBLE' in totals['intel_8pmc3']:
+                value = (numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_SCALAR_DOUBLE']))
+                flops += value
+                double_flops += value
+            if 'FP_ARITH_INST_RETIRED_SCALAR_SINGLE' in totals['intel_8pmc3']:
+                value = (numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_SCALAR_SINGLE']))
+                flops += value
+                single_flops += value
+            if 'FP_ARITH_INST_RETIRED_128B_PACKED_DOUBLE' in totals['intel_8pmc3']:
+                value = (2.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_128B_PACKED_DOUBLE']))
+                flops += value
+                double_flops += value
+            if 'FP_ARITH_INST_RETIRED_128B_PACKED_SINGLE' in totals['intel_8pmc3']:
+                value = (4.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_128B_PACKED_SINGLE']))
+                flops += value
+                single_flops += value
+            if 'FP_ARITH_INST_RETIRED_256B_PACKED_DOUBLE' in totals['intel_8pmc3']:
+                value = (4.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_256B_PACKED_DOUBLE']))
+                flops += value
+                double_flops += value
+            if 'FP_ARITH_INST_RETIRED_256B_PACKED_SINGLE' in totals['intel_8pmc3']:
+                value = (8.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_256B_PACKED_SINGLE']))
+                flops += value
+                single_flops += value
+            if 'FP_ARITH_INST_RETIRED_512B_PACKED_DOUBLE' in totals['intel_8pmc3']:
+                value = (8.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_512B_PACKED_DOUBLE']))
+                flops += value
+                double_flops += value
+            if 'FP_ARITH_INST_RETIRED_512B_PACKED_SINGLE' in totals['intel_8pmc3']:
+                value = (16.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_512B_PACKED_SINGLE']))
+                flops += value
+                single_flops += value
+
+            summaryDict['FLOPS'] = calculate_stats(flops)
+            summaryDict['FLOPS_SINGLE'] = calculate_stats(single_flops)
+            summaryDict['FLOPS_DOUBLE'] = calculate_stats(double_flops)
 
         # TODO - make this stuff configurable
         if 'lnet' in totals.keys() and 'rx_bytes' in totals['lnet'] and '-' in totals['lnet']["rx_bytes"]:
@@ -793,6 +831,8 @@ def summarize(j, lariatcache):
                         summaryDict['mpirx'] = calculate_stats(mpitraff);
                 else:
                     summaryDict['mpirx'] = { 'error': 2, 'error_msg': 'missing ib_sw or lnet data points' }
+
+
 
         del totals['cpu']
 

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -194,9 +194,9 @@ def gentimedata(j, indices, ignorelist, isevent):
             if '.' in i:
                 continue
             if m == "cpu":
-                results[m][i] = calculate_stats( numpy.diff(a) / numpy.diff(hostdata[m]["all"]) )
+                results[m][i] = calculate_stats( numpy.nan_to_num(numpy.diff(a) / numpy.diff(hostdata[m]["all"])) )
             elif isevent[m][i]:
-                results[m][i] = calculate_stats( numpy.diff(a) / numpy.diff(times) )
+                results[m][i] = calculate_stats( numpy.nan_to_num( numpy.diff(a) / numpy.diff(times) ))
             else:
                 results[m][i] = calculate_stats( a )
 

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -653,11 +653,6 @@ def summarize(j, lariatcache):
                     compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'INSTRUCTIONS_RETIRED', corederived["cpiref"])
                     compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'MEM_LOAD_RETIRED_L1D_HIT', corederived["cpldref"])
 
-                elif metricname == "intel_8pmc3":
-                    compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_CORE', 'INSTRUCTIONS_RETIRED', corederived["cpicore"])
-                    compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'INSTRUCTIONS_RETIRED', corederived["cpiref"])
-                    compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'MEM_LOAD_RETIRED_L1D_HIT', corederived["cpldref"])
-
                 elif metricname == "intel_snb_imc" or metricname == "intel_skx_imc" or metricname == "intel_hsw_imc" or metricname == "intel_ivb_imc" or metricname == "intel_knl_mc_dclk":
                     if metricname not in j.overflows:
                         compute_sum(host.stats[metricname][device], indices[metricname], 'CAS_READS', 'CAS_WRITES', socketderived["membw"], hostwalltime / 64.0 )

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -859,7 +859,7 @@ def summarize(j, lariatcache):
     summaryDict['collection_sw'] = "tacc_stats " + " ".join(tacc_version)
 
     # add account info from slurm accounting files
-    summaryDict['acct'] = job.acct
+    summaryDict['acct'] = j.acct
 
     # add schema outline
     if statsOk and not COMPACT_OUTPUT:

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -603,7 +603,11 @@ def summarize(j, lariatcache):
                             if interface not in totals[metricname]:
                                 totals[metricname][interface] = []
 
-                            totals[metricname][interface].append( host.stats[metricname][device][-1,index] / hostwalltime )
+                            # We expect / allow data to be absent and as such need to check that it's present before
+                            # accessing it for summarization.
+                            (num, shape_len) = host.stats[metricname][device].shape
+                            if index < shape_len:
+                                totals[metricname][interface].append( host.stats[metricname][device][-1,index] / hostwalltime )
                         else:
                             # Generate values for all enties
                             if interface not in totals[metricname]:

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -422,7 +422,8 @@ def getperinterfacemetrics():
                      "intel_ivb_pcu",
                      "intel_ivb_r2pci",
              "intel_8pmc3",
-             "intel_4pmc3"]
+             "intel_4pmc3"
+             "intel_skx_cha"]
 
 
 def fix_unicode(value):

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -653,6 +653,11 @@ def summarize(j, lariatcache):
                     compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'INSTRUCTIONS_RETIRED', corederived["cpiref"])
                     compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'MEM_LOAD_RETIRED_L1D_HIT', corederived["cpldref"])
 
+                elif metricname == "intel_4pmc3" or metricname == 'intel_8pmc3':
+                    compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_CORE', 'INSTRUCTIONS_RETIRED', corederived["cpicore"])
+                    compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'INSTRUCTIONS_RETIRED', corederived["cpiref"])
+                    compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'LOAD_L1D_ALL', corederived["cpldref"])
+
                 elif metricname == "intel_snb_imc" or metricname == "intel_skx_imc" or metricname == "intel_hsw_imc" or metricname == "intel_ivb_imc" or metricname == "intel_knl_mc_dclk":
                     if metricname not in j.overflows:
                         compute_sum(host.stats[metricname][device], indices[metricname], 'CAS_READS', 'CAS_WRITES', socketderived["membw"], hostwalltime / 64.0 )

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -787,39 +787,40 @@ def summarize(j, lariatcache):
 
         # New Cascade Lake flop calculations
         if 'intel_8pmc3' in totals.keys():
-            flops = single_flops = double_flops = 0.0
+            flops = None
+            single_flops = None
+            double_flops = None
             if 'FP_ARITH_INST_RETIRED_SCALAR_DOUBLE' in totals['intel_8pmc3']:
-                value = (numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_SCALAR_DOUBLE']))
-                flops += value
-                double_flops += value
+                value = numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_SCALAR_DOUBLE'])
+                flops = value if flops is None else numpy.add(flops, value)
+                double_flops = value if double_flops is None else numpy.add(double_flops, value)
             if 'FP_ARITH_INST_RETIRED_SCALAR_SINGLE' in totals['intel_8pmc3']:
-                value = (numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_SCALAR_SINGLE']))
-                flops += value
-                single_flops += value
+                value = numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_SCALAR_SINGLE'])
+                single_flops = value if single_flops is None else numpy.add(single_flops, value)
             if 'FP_ARITH_INST_RETIRED_128B_PACKED_DOUBLE' in totals['intel_8pmc3']:
-                value = (2.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_128B_PACKED_DOUBLE']))
-                flops += value
-                double_flops += value
+                value = 2.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_128B_PACKED_DOUBLE'])
+                flops = value if flops is None else numpy.add(flops, value)
+                double_flops = value if double_flops is None else numpy.add(double_flops, value)
             if 'FP_ARITH_INST_RETIRED_128B_PACKED_SINGLE' in totals['intel_8pmc3']:
-                value = (4.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_128B_PACKED_SINGLE']))
-                flops += value
-                single_flops += value
+                value = 4.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_128B_PACKED_SINGLE'])
+                flops = value if flops is None else numpy.add(flops, value)
+                single_flops = value if single_flops is None else numpy.add(single_flops, value)
             if 'FP_ARITH_INST_RETIRED_256B_PACKED_DOUBLE' in totals['intel_8pmc3']:
-                value = (4.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_256B_PACKED_DOUBLE']))
-                flops += value
-                double_flops += value
+                value = 4.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_256B_PACKED_DOUBLE'])
+                flops = value if flops is None else numpy.add(flops, value)
+                double_flops = value if double_flops is None else numpy.add(double_flops, value)
             if 'FP_ARITH_INST_RETIRED_256B_PACKED_SINGLE' in totals['intel_8pmc3']:
-                value = (8.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_256B_PACKED_SINGLE']))
-                flops += value
-                single_flops += value
+                value = 8.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_256B_PACKED_SINGLE'])
+                flops = value if flops is None else numpy.add(flops, value)
+                single_flops = value if single_flops is None else numpy.add(single_flops, value)
             if 'FP_ARITH_INST_RETIRED_512B_PACKED_DOUBLE' in totals['intel_8pmc3']:
-                value = (8.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_512B_PACKED_DOUBLE']))
-                flops += value
-                double_flops += value
+                value = 8.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_512B_PACKED_DOUBLE'])
+                flops = value if flops is None else numpy.add(flops, value)
+                double_flops = value if double_flops is None else numpy.add(double_flops, value)
             if 'FP_ARITH_INST_RETIRED_512B_PACKED_SINGLE' in totals['intel_8pmc3']:
-                value = (16.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_512B_PACKED_SINGLE']))
-                flops += value
-                single_flops += value
+                value = 16.0 * numpy.array(totals['intel_8pmc3']['FP_ARITH_INST_RETIRED_512B_PACKED_SINGLE'])
+                flops = value if flops is None else numpy.add(flops, value)
+                single_flops = value if single_flops is None else numpy.add(single_flops, value)
 
             summaryDict['FLOPS'] = calculate_stats(flops)
             summaryDict['FLOPS_SINGLE'] = calculate_stats(single_flops)

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -854,7 +854,7 @@ def summarize(j, lariatcache):
     # add hosts
     summaryDict['hosts'] = []
     for i in j.hosts.keys():
-        summaryDict['hosts'].append(i.encode('ascii', 'ignore') if type(i) == unicode else i)
+        summaryDict['hosts'].append(i)
 
     summaryDict['collection_sw'] = "tacc_stats " + " ".join(tacc_version)
 

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -426,6 +426,12 @@ def getperinterfacemetrics():
 
 
 def fix_unicode(value):
+    """
+    This function helps convert a given value, recursively, from unicode to ascii.
+
+    :param value:
+    :return:
+    """
     if type(value) == unicode:
         return value.encode('ascii', 'ignore')
     elif type(value) == dict:

--- a/pickler/summarize.py
+++ b/pickler/summarize.py
@@ -113,7 +113,11 @@ def gentimedata(j, indices, ignorelist, isevent):
             "intel_pmc3": {
                 "meancpiref":  [ "numpy.diff(a[0])/numpy.diff(a[1])", "CLOCKS_UNHALTED_REF", "INSTRUCTIONS_RETIRED" ],
                 "meancpldref": [ "numpy.diff(a[0])/numpy.diff(a[1])", "CLOCKS_UNHALTED_REF", "MEM_LOAD_RETIRED_L1D_HIT" ],
-            }
+            },
+        "intel_8pmc3": {
+            "meancpiref":  [ "numpy.diff(a[0])/numpy.diff(a[1])", "CLOCKS_UNHALTED_REF", "INSTRUCTIONS_RETIRED" ],
+            "meancpldref": [ "numpy.diff(a[0])/numpy.diff(a[1])", "CLOCKS_UNHALTED_REF", "MEM_LOAD_RETIRED_L1D_HIT" ],
+        }
     }
 
     computed = {
@@ -645,6 +649,11 @@ def summarize(j, lariatcache):
                         compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'INSTRUCTIONS_RETIRED', corederived["cpiref"])
 
                 elif metricname == "intel_pmc3":
+                    compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_CORE', 'INSTRUCTIONS_RETIRED', corederived["cpicore"])
+                    compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'INSTRUCTIONS_RETIRED', corederived["cpiref"])
+                    compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'MEM_LOAD_RETIRED_L1D_HIT', corederived["cpldref"])
+
+                elif metricname == "intel_8pmc3":
                     compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_CORE', 'INSTRUCTIONS_RETIRED', corederived["cpicore"])
                     compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'INSTRUCTIONS_RETIRED', corederived["cpiref"])
                     compute_ratio(host.stats[metricname][device], indices[metricname], 'CLOCKS_UNHALTED_REF', 'MEM_LOAD_RETIRED_L1D_HIT', corederived["cpldref"])


### PR DESCRIPTION
- Added a new Batch Account class `OpenXDMoDSlurm` for dealing with the accounting data from frontera. 
- Updated intel_process.py with updated event_map's 
- Updated job_stats.py to handle both gzip'd and non-gzip'd files
- Updated the MongoOutput class to accept more granular authentication information that is appropriately encoded. Also added a fallback exception handler to help with debugging. 
- Updated process.py to properly explode the `node_list` property if found and save it as the `host_list` property. This is due to Frontera not having a `host_list` property by default but it does have a `node_list` property. `host_list` is expected to be an array of strings while `node_list` is a string that contains all of the nodes the job ran on. A library already existed that takes care of parsing this information so it is being used here. 
- Updated `pickler/summarize.py` with the new interfaces that Frontera provides that will need to be processed. 
  - Also ran into the python 2.X strings vs. unicode problem so added a small helper function to
   convert from a unicode strings on their own or found in dicts / lists into ascii strings. 
  - While trying to read through / understand the code I was getting lost with all of the single letter variables so refactored `j` to `job`. There's still a lot of single letter variables but this helps a little bit at least. 
  - Added the total, single and double FLOPS calculation code for Frontera

There are still a host of other modifications that will need to be taken into account namely, frontera's dataset map, an updated `etl/etl_tables.d/supremm/job.json` file to account for the new double / single flop statistics, and possible a few more. There will be additional pull requests submitted for these changes to their respective repo's.  