### PR TITLE
Rescale CPU metrics for Skylake.

### DIFF
--- a/pickler/phys_cores_process.py
+++ b/pickler/phys_cores_process.py
@@ -2,6 +2,32 @@
 import numpy
 import os
 
+def intel_skx_map(virtcore):
+    """ return the physical core index given the (virtual) cpu number """
+    return virtcore % 48
+
+def intel_skx_rescale(a, idleidx):
+
+    totalticks = sum(a)
+    if totalticks == 0:
+        # has been seen in the data
+        return a
+
+    idle = a[idleidx] / sum(a)
+
+    if idle > 0.5:
+        a[idleidx] -= numpy.uint64(0.5 * sum(a))
+    else:
+        # total counts
+        newticks = 0.5 * sum(a)
+
+        # Set idle to zero and preserve the relative proportions of the other counters
+        a[idleidx] = numpy.uint64(0)
+        nonidleticks = sum(a)
+        a = numpy.uint64(a * newticks / nonidleticks)
+
+    return a
+
 def intel_knl_map(virtcore):
     """ return the physical core index given the (virtual) cpu number """
     return virtcore % 68
@@ -54,6 +80,28 @@ def process_job(job):
                 if len(output[key][:, ]) > 1:
                     rates = numpy.diff(output[key], 1, 0)
                     scaled_rates = numpy.apply_along_axis(intel_knl_rescale, 1, rates, cpuidle)
+                    output[key] = numpy.concatenate(( (output[key][0], ), scaled_rates), 0).cumsum(0)
+
+            host.stats['cputhreads'] = host.stats['cpu']
+            job.get_schema('cputhreads', cpuschema.desc)
+            host.stats['cpu'] = output
+
+        if len(cpustats) == 96:
+            output = {}
+            for cpuidx, data in cpustats.iteritems():
+                realidx = str(intel_skx_map(int(cpuidx)))
+                if realidx not in output:
+                    output[realidx] = data
+                else:
+                    output[realidx] += data
+
+            cpuschema = job.get_schema('cpu')
+            cpuidle = cpuschema['idle'].index
+
+            for key in output.keys():
+                if len(output[key][:, ]) > 1:
+                    rates = numpy.diff(output[key], 1, 0)
+                    scaled_rates = numpy.apply_along_axis(intel_skx_rescale, 1, rates, cpuidle)
                     output[key] = numpy.concatenate(( (output[key][0], ), scaled_rates), 0).cumsum(0)
 
             host.stats['cputhreads'] = host.stats['cpu']


### PR DESCRIPTION
The CPU metrics on Skylake are rescaled to produce an estimate of the physical
core usage rather than the thread usage. The thread data is retained and stored in
the cputhreads record.